### PR TITLE
Add unit tests for some of the core services

### DIFF
--- a/Data_Access_Layer/ApplicationDbContext.cs
+++ b/Data_Access_Layer/ApplicationDbContext.cs
@@ -22,6 +22,7 @@ namespace Data_Access_Layer
         public DbSet<Author> Authors { get; set; }
         public DbSet<Publisher> Publishers { get; set; }
         public DbSet<Wishlist> Wishlists { get; set; }
+        public DbSet<WishlistBook> WishlistBooks { get; set; }
         public DbSet<Event> Events { get; set; }
         public DbSet<BookEvent> BookEvents { get; set; }
 

--- a/FBookRating.Tests/Services/EventServiceTests.cs
+++ b/FBookRating.Tests/Services/EventServiceTests.cs
@@ -1,0 +1,179 @@
+using Xunit;
+using Data_Access_Layer.Entities;
+using Data_Access_Layer.UnitOfWork;
+using FBookRating.Services;
+using FBookRating.Models.DTOs.Event;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+using Data_Access_Layer;
+
+namespace FBookRating.Tests.Services
+{
+    public class EventServiceTests
+    {
+        private DbContextOptions<ApplicationDbContext> CreateNewContextOptions(string dbName)
+            => new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(databaseName: dbName)
+                .Options;
+
+        [Fact]
+        public async Task GetAllEventsAsync_ShouldReturnAllEvents()
+        {
+            var opts = CreateNewContextOptions(nameof(GetAllEventsAsync_ShouldReturnAllEvents));
+            using (var seedContext = new ApplicationDbContext(opts))
+            {
+                seedContext.Events.AddRange(
+                    new Event { Id = Guid.NewGuid(), Name = "Event 1", Location = "Location 1", StartDate = DateTime.Now, Description = "Description 1" },
+                    new Event { Id = Guid.NewGuid(), Name = "Event 2", Location = "Location 2", StartDate = DateTime.Now, Description = "Description 2" }
+                );
+                seedContext.SaveChanges();
+            }
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new EventService(new UnitOfWork(context));
+                var result = await service.GetAllEventsAsync();
+                Assert.NotNull(result);
+                Assert.Equal(2, result.Count());
+            }
+        }
+
+        [Fact]
+        public async Task GetEventByIdAsync_WithValidId_ShouldReturnEvent()
+        {
+            var opts = CreateNewContextOptions(nameof(GetEventByIdAsync_WithValidId_ShouldReturnEvent));
+            var eventId = Guid.NewGuid();
+            using (var seedContext = new ApplicationDbContext(opts))
+            {
+                seedContext.Events.Add(new Event
+                {
+                    Id = eventId,
+                    Name = "Test Event",
+                    Location = "Test Location",
+                    StartDate = DateTime.Now,
+                    Description = "Test Description"
+                });
+                seedContext.SaveChanges();
+            }
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new EventService(new UnitOfWork(context));
+                var result = await service.GetEventByIdAsync(eventId);
+                Assert.NotNull(result);
+                Assert.Equal(eventId, result.Id);
+                Assert.Equal("Test Event", result.Name);
+            }
+        }
+
+        [Fact]
+        public async Task AddEventAsync_ShouldCreateNewEvent()
+        {
+            var opts = CreateNewContextOptions(nameof(AddEventAsync_ShouldCreateNewEvent));
+            var newEventDTO = new EventCreateDTO
+            {
+                Name = "New Event",
+                Location = "New Location",
+                StartDate = DateTime.Now,
+                Description = "New Description"
+            };
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new EventService(new UnitOfWork(context));
+                await service.AddEventAsync(newEventDTO);
+            }
+
+            using (var verifyContext = new ApplicationDbContext(opts))
+            {
+                var ev = verifyContext.Events.SingleOrDefault(e => e.Name == "New Event");
+                Assert.NotNull(ev);
+                Assert.Equal("New Location", ev.Location);
+                Assert.Equal("New Description", ev.Description);
+            }
+        }
+
+        [Fact]
+        public async Task AddBookToEventAsync_ShouldCreateBookEvent()
+        {
+            var opts = CreateNewContextOptions(nameof(AddBookToEventAsync_ShouldCreateBookEvent));
+            var eventId = Guid.NewGuid();
+            var bookId = Guid.NewGuid();
+            using (var seedContext = new ApplicationDbContext(opts))
+            {
+                seedContext.Events.Add(new Event {
+                    Id = eventId,
+                    Name = "Event",
+                    Description = "desc",
+                    Location = "loc",
+                    StartDate = DateTime.UtcNow
+                });
+                seedContext.Books.Add(new Book {
+                    Id = bookId,
+                    Title = "Book",
+                    CoverImageUrl = "cover.jpg",
+                    Description = "desc",
+                    ISBN = "isbn",
+                    PublishedDate = DateTime.UtcNow,
+                    CategoryId = Guid.NewGuid()
+                });
+                seedContext.SaveChanges();
+            }
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new EventService(new UnitOfWork(context));
+                await service.AddBookToEventAsync(eventId, bookId);
+            }
+
+            using (var verifyContext = new ApplicationDbContext(opts))
+            {
+                var bookEvent = verifyContext.BookEvents.SingleOrDefault(be => be.EventId == eventId && be.BookId == bookId);
+                Assert.NotNull(bookEvent);
+            }
+        }
+
+        [Fact]
+        public async Task RemoveBookFromEventAsync_ShouldDeleteBookEvent()
+        {
+            var opts = CreateNewContextOptions(nameof(RemoveBookFromEventAsync_ShouldDeleteBookEvent));
+            var eventId = Guid.NewGuid();
+            var bookId = Guid.NewGuid();
+            using (var seedContext = new ApplicationDbContext(opts))
+            {
+                seedContext.Events.Add(new Event {
+                    Id = eventId,
+                    Name = "Event",
+                    Description = "desc",
+                    Location = "loc",
+                    StartDate = DateTime.UtcNow
+                });
+                seedContext.Books.Add(new Book {
+                    Id = bookId,
+                    Title = "Book",
+                    CoverImageUrl = "cover.jpg",
+                    Description = "desc",
+                    ISBN = "isbn",
+                    PublishedDate = DateTime.UtcNow,
+                    CategoryId = Guid.NewGuid()
+                });
+                seedContext.BookEvents.Add(new BookEvent { EventId = eventId, BookId = bookId });
+                seedContext.SaveChanges();
+            }
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new EventService(new UnitOfWork(context));
+                await service.RemoveBookFromEventAsync(eventId, bookId);
+            }
+
+            using (var verifyContext = new ApplicationDbContext(opts))
+            {
+                var bookEvent = verifyContext.BookEvents.SingleOrDefault(be => be.EventId == eventId && be.BookId == bookId);
+                Assert.Null(bookEvent);
+            }
+        }
+    }
+} 

--- a/FBookRating.Tests/Services/PublisherServiceTests.cs
+++ b/FBookRating.Tests/Services/PublisherServiceTests.cs
@@ -1,0 +1,160 @@
+using Xunit;
+using Data_Access_Layer.Entities;
+using Data_Access_Layer.UnitOfWork;
+using FBookRating.Services;
+using FBookRating.Models.DTOs.Publisher;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+using Data_Access_Layer;
+
+namespace FBookRating.Tests.Services
+{
+    public class PublisherServiceTests
+    {
+        private DbContextOptions<ApplicationDbContext> CreateNewContextOptions(string dbName)
+            => new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(databaseName: dbName)
+                .Options;
+
+        [Fact]
+        public async Task GetAllPublishersAsync_ShouldReturnAllPublishers()
+        {
+            var opts = CreateNewContextOptions(nameof(GetAllPublishersAsync_ShouldReturnAllPublishers));
+            using (var seedContext = new ApplicationDbContext(opts))
+            {
+                seedContext.Publishers.AddRange(
+                    new Publisher { Id = Guid.NewGuid(), Name = "Publisher 1", Website = "www.publisher1.com", Address = "Address 1" },
+                    new Publisher { Id = Guid.NewGuid(), Name = "Publisher 2", Website = "www.publisher2.com", Address = "Address 2" }
+                );
+                seedContext.SaveChanges();
+            }
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new PublisherService(new UnitOfWork(context));
+                var result = await service.GetAllPublishersAsync();
+                Assert.NotNull(result);
+                Assert.Equal(2, result.Count());
+            }
+        }
+
+        [Fact]
+        public async Task GetPublisherByIdAsync_WithValidId_ShouldReturnPublisher()
+        {
+            var opts = CreateNewContextOptions(nameof(GetPublisherByIdAsync_WithValidId_ShouldReturnPublisher));
+            var publisherId = Guid.NewGuid();
+            using (var seedContext = new ApplicationDbContext(opts))
+            {
+                seedContext.Publishers.Add(new Publisher
+                {
+                    Id = publisherId,
+                    Name = "Test Publisher",
+                    Website = "www.test.com",
+                    Address = "Test Address"
+                });
+                seedContext.SaveChanges();
+            }
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new PublisherService(new UnitOfWork(context));
+                var result = await service.GetPublisherByIdAsync(publisherId);
+                Assert.NotNull(result);
+                Assert.Equal(publisherId, result.Id);
+                Assert.Equal("Test Publisher", result.Name);
+            }
+        }
+
+        [Fact]
+        public async Task AddPublisherAsync_ShouldCreateNewPublisher()
+        {
+            var opts = CreateNewContextOptions(nameof(AddPublisherAsync_ShouldCreateNewPublisher));
+            var newPublisherDTO = new PublisherCreateDTO
+            {
+                Name = "New Publisher",
+                Website = "www.newpublisher.com",
+                Address = "New Address"
+            };
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new PublisherService(new UnitOfWork(context));
+                await service.AddPublisherAsync(newPublisherDTO);
+            }
+
+            using (var verifyContext = new ApplicationDbContext(opts))
+            {
+                var publisher = verifyContext.Publishers.SingleOrDefault(p => p.Name == "New Publisher");
+                Assert.NotNull(publisher);
+                Assert.Equal("www.newpublisher.com", publisher.Website);
+                Assert.Equal("New Address", publisher.Address);
+            }
+        }
+
+        [Fact]
+        public async Task UpdatePublisherAsync_WithValidId_ShouldUpdatePublisher()
+        {
+            var opts = CreateNewContextOptions(nameof(UpdatePublisherAsync_WithValidId_ShouldUpdatePublisher));
+            var publisherId = Guid.NewGuid();
+            using (var seedContext = new ApplicationDbContext(opts))
+            {
+                seedContext.Publishers.Add(new Publisher
+                {
+                    Id = publisherId,
+                    Name = "Old Name",
+                    Website = "www.old.com",
+                    Address = "Old Address"
+                });
+                seedContext.SaveChanges();
+            }
+
+            var updateDTO = new PublisherUpdateDTO
+            {
+                Name = "Updated Name",
+                Website = "www.updated.com",
+                Address = "Updated Address"
+            };
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new PublisherService(new UnitOfWork(context));
+                await service.UpdatePublisherAsync(publisherId, updateDTO);
+            }
+
+            using (var verifyContext = new ApplicationDbContext(opts))
+            {
+                var publisher = verifyContext.Publishers.SingleOrDefault(p => p.Id == publisherId);
+                Assert.NotNull(publisher);
+                Assert.Equal("Updated Name", publisher.Name);
+                Assert.Equal("www.updated.com", publisher.Website);
+                Assert.Equal("Updated Address", publisher.Address);
+            }
+        }
+
+        [Fact]
+        public async Task DeletePublisherAsync_WithValidId_ShouldDeletePublisher()
+        {
+            var opts = CreateNewContextOptions(nameof(DeletePublisherAsync_WithValidId_ShouldDeletePublisher));
+            var publisherId = Guid.NewGuid();
+            using (var seedContext = new ApplicationDbContext(opts))
+            {
+                seedContext.Publishers.Add(new Publisher { Id = publisherId, Name = "ToDelete", Website = "www.todelete.com", Address = "Delete Address" });
+                seedContext.SaveChanges();
+            }
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new PublisherService(new UnitOfWork(context));
+                await service.DeletePublisherAsync(publisherId);
+            }
+
+            using (var verifyContext = new ApplicationDbContext(opts))
+            {
+                var publisher = verifyContext.Publishers.SingleOrDefault(p => p.Id == publisherId);
+                Assert.Null(publisher);
+            }
+        }
+    }
+} 

--- a/FBookRating.Tests/Services/UserServiceTests.cs
+++ b/FBookRating.Tests/Services/UserServiceTests.cs
@@ -1,0 +1,132 @@
+using Xunit;
+using Data_Access_Layer.Entities;
+using Data_Access_Layer.UnitOfWork;
+using FBookRating.Services;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+using Data_Access_Layer;
+
+namespace FBookRating.Tests.Services
+{
+    public class UserServiceTests
+    {
+        private DbContextOptions<ApplicationDbContext> CreateNewContextOptions(string dbName)
+            => new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(databaseName: dbName)
+                .Options;
+
+        [Fact]
+        public async Task CreateOrUpdateUserAsync_WithNewUser_ShouldCreateUser()
+        {
+            var opts = CreateNewContextOptions(nameof(CreateOrUpdateUserAsync_WithNewUser_ShouldCreateUser));
+            var userId = "auth0|test-user-id";
+            var userName = "testuser";
+            var displayName = "Test User";
+            var email = "test@example.com";
+            var profilePictureUrl = "https://example.com/profile.jpg";
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new UserService(new UnitOfWork(context));
+                await service.CreateOrUpdateUserAsync(userId, userName, displayName, email, profilePictureUrl);
+            }
+
+            using (var verifyContext = new ApplicationDbContext(opts))
+            {
+                var user = verifyContext.Users.SingleOrDefault(u => u.Id == userId);
+                Assert.NotNull(user);
+                Assert.Equal(userName, user.UserName);
+                Assert.Equal(displayName, user.DisplayName);
+                Assert.Equal(email, user.Email);
+                Assert.Equal(profilePictureUrl, user.ProfilePictureUrl);
+            }
+        }
+
+        [Fact]
+        public async Task CreateOrUpdateUserAsync_WithExistingUser_ShouldUpdateUser()
+        {
+            var opts = CreateNewContextOptions(nameof(CreateOrUpdateUserAsync_WithExistingUser_ShouldUpdateUser));
+            var userId = "auth0|test-user-id";
+            using (var seedContext = new ApplicationDbContext(opts))
+            {
+                seedContext.Users.Add(new ApplicationUser
+                {
+                    Id = userId,
+                    UserName = "oldusername",
+                    DisplayName = "Old Name",
+                    Email = "old@example.com",
+                    ProfilePictureUrl = "https://example.com/old.jpg"
+                });
+                seedContext.SaveChanges();
+            }
+
+            var userName = "testuser";
+            var displayName = "Test User";
+            var email = "test@example.com";
+            var profilePictureUrl = "https://example.com/profile.jpg";
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new UserService(new UnitOfWork(context));
+                await service.CreateOrUpdateUserAsync(userId, userName, displayName, email, profilePictureUrl);
+            }
+
+            using (var verifyContext = new ApplicationDbContext(opts))
+            {
+                var user = verifyContext.Users.SingleOrDefault(u => u.Id == userId);
+                Assert.NotNull(user);
+                Assert.Equal(userName, user.UserName);
+                Assert.Equal(displayName, user.DisplayName);
+                Assert.Equal(email, user.Email);
+                Assert.Equal(profilePictureUrl, user.ProfilePictureUrl);
+            }
+        }
+
+        [Fact]
+        public async Task CreateOrUpdateUserAsync_WithInvalidAuth0Id_ShouldNotThrowException()
+        {
+            var opts = CreateNewContextOptions(nameof(CreateOrUpdateUserAsync_WithInvalidAuth0Id_ShouldNotThrowException));
+            var invalidUserId = "invalid-user-id"; // Missing Auth0 prefix
+            var userName = "testuser";
+            var displayName = "Test User";
+            var email = "test@example.com";
+            var profilePictureUrl = "https://example.com/profile.jpg";
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new UserService(new UnitOfWork(context));
+                await service.CreateOrUpdateUserAsync(invalidUserId, userName, displayName, email, profilePictureUrl);
+                // No exception expected
+            }
+        }
+
+        [Fact]
+        public async Task CreateOrUpdateUserAsync_WithSocialLogin_ShouldHandleEmptyUsername()
+        {
+            var opts = CreateNewContextOptions(nameof(CreateOrUpdateUserAsync_WithSocialLogin_ShouldHandleEmptyUsername));
+            var userId = "auth0|social-user-id";
+            var userName = ""; // Social login might not provide username
+            var displayName = "Social User";
+            var email = "social@example.com";
+            var profilePictureUrl = "https://example.com/profile.jpg";
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new UserService(new UnitOfWork(context));
+                await service.CreateOrUpdateUserAsync(userId, userName, displayName, email, profilePictureUrl);
+            }
+
+            using (var verifyContext = new ApplicationDbContext(opts))
+            {
+                var user = verifyContext.Users.SingleOrDefault(u => u.Id == userId);
+                Assert.NotNull(user);
+                Assert.Equal("", user.UserName); // Service leaves username empty
+                Assert.Equal(displayName, user.DisplayName);
+                Assert.Equal(email, user.Email);
+                Assert.Equal(profilePictureUrl, user.ProfilePictureUrl);
+            }
+        }
+    }
+} 

--- a/FBookRating.Tests/Services/WishlistServiceTests.cs
+++ b/FBookRating.Tests/Services/WishlistServiceTests.cs
@@ -1,0 +1,223 @@
+using Xunit;
+using Data_Access_Layer.Entities;
+using Data_Access_Layer.UnitOfWork;
+using FBookRating.Services;
+using FBookRating.Models.DTOs.WishList;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+using System.Collections.Generic;
+using Data_Access_Layer;
+
+namespace FBookRating.Tests.Services
+{
+    public class WishlistServiceTests
+    {
+        private DbContextOptions<ApplicationDbContext> CreateNewContextOptions(string dbName)
+            => new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(databaseName: dbName)
+                .Options;
+
+        [Fact]
+        public async Task GetWishlistsByUserAsync_ShouldReturnUserWishlists()
+        {
+            var opts = CreateNewContextOptions(nameof(GetWishlistsByUserAsync_ShouldReturnUserWishlists));
+            var userId = "test-user-id";
+            var wishlistId = Guid.NewGuid();
+            using (var seedContext = new ApplicationDbContext(opts))
+            {
+                var bookId = Guid.NewGuid();
+                seedContext.Books.Add(new Book {
+                    Id = bookId,
+                    Title = "Book 1",
+                    CoverImageUrl = "cover1.jpg",
+                    Description = "desc1",
+                    ISBN = "isbn1",
+                    PublishedDate = DateTime.UtcNow,
+                    CategoryId = Guid.NewGuid()
+                });
+                seedContext.Wishlists.Add(new Wishlist
+                {
+                    Id = wishlistId,
+                    Name = "Wishlist 1",
+                    UserId = userId,
+                    WishlistBooks = new List<WishlistBook>
+                    {
+                        new WishlistBook
+                        {
+                            BookId = bookId,
+                            AddedDate = DateTime.UtcNow
+                        }
+                    }
+                });
+                seedContext.SaveChanges();
+            }
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new WishlistService(new UnitOfWork(context));
+                var result = await service.GetWishlistsByUserAsync(userId);
+                Assert.NotNull(result);
+                Assert.Single(result);
+                Assert.Equal("Wishlist 1", result.First().Name);
+                Assert.Single(result.First().Books);
+            }
+        }
+
+        [Fact]
+        public async Task GetWishlistsByUserAsync_WhenUserHasNoWishlists_ShouldReturnEmptyList()
+        {
+            var opts = CreateNewContextOptions(nameof(GetWishlistsByUserAsync_WhenUserHasNoWishlists_ShouldReturnEmptyList));
+            var userId = "test-user-id";
+            // No seeding
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new WishlistService(new UnitOfWork(context));
+                var result = await service.GetWishlistsByUserAsync(userId);
+                Assert.NotNull(result);
+                Assert.Empty(result);
+            }
+        }
+
+        [Fact]
+        public async Task AddWishlistAsync_ShouldCreateNewWishlist()
+        {
+            var opts = CreateNewContextOptions(nameof(AddWishlistAsync_ShouldCreateNewWishlist));
+            var userId = "test-user-id";
+            var wishlistDTO = new WishlistCreateDTO { Name = "New Wishlist" };
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new WishlistService(new UnitOfWork(context));
+                await service.AddWishlistAsync(wishlistDTO, userId);
+            }
+
+            using (var verifyContext = new ApplicationDbContext(opts))
+            {
+                var wishlist = verifyContext.Wishlists.SingleOrDefault(w => w.UserId == userId);
+                Assert.NotNull(wishlist);
+                Assert.Equal("New Wishlist", wishlist.Name);
+            }
+        }
+
+        [Fact]
+        public async Task AddBookToWishlistAsync_WhenBookNotInWishlist_ShouldAddBook()
+        {
+            var opts = CreateNewContextOptions(nameof(AddBookToWishlistAsync_WhenBookNotInWishlist_ShouldAddBook));
+            var wishlistId = Guid.NewGuid();
+            var bookId = Guid.NewGuid();
+            using (var seedContext = new ApplicationDbContext(opts))
+            {
+                seedContext.Books.Add(new Book {
+                    Id = bookId,
+                    Title = "Book",
+                    CoverImageUrl = "cover.jpg",
+                    Description = "desc",
+                    ISBN = "isbn",
+                    PublishedDate = DateTime.UtcNow,
+                    CategoryId = Guid.NewGuid()
+                });
+                seedContext.Wishlists.Add(new Wishlist { Id = wishlistId, Name = "Wishlist", UserId = "user" });
+                seedContext.SaveChanges();
+            }
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new WishlistService(new UnitOfWork(context));
+                await service.AddBookToWishlistAsync(wishlistId, bookId);
+            }
+
+            using (var verifyContext = new ApplicationDbContext(opts))
+            {
+                var wishlistBook = verifyContext.WishlistBooks.SingleOrDefault(wb => wb.WishlistId == wishlistId && wb.BookId == bookId);
+                Assert.NotNull(wishlistBook);
+            }
+        }
+
+        [Fact]
+        public async Task AddBookToWishlistAsync_WhenBookAlreadyInWishlist_ShouldNotAddBook()
+        {
+            var opts = CreateNewContextOptions(nameof(AddBookToWishlistAsync_WhenBookAlreadyInWishlist_ShouldNotAddBook));
+            var wishlistId = Guid.NewGuid();
+            var bookId = Guid.NewGuid();
+            using (var seedContext = new ApplicationDbContext(opts))
+            {
+                seedContext.Books.Add(new Book {
+                    Id = bookId,
+                    Title = "Book",
+                    CoverImageUrl = "cover.jpg",
+                    Description = "desc",
+                    ISBN = "isbn",
+                    PublishedDate = DateTime.UtcNow,
+                    CategoryId = Guid.NewGuid()
+                });
+                seedContext.Wishlists.Add(new Wishlist { Id = wishlistId, Name = "Wishlist", UserId = "user" });
+                seedContext.WishlistBooks.Add(new WishlistBook { WishlistId = wishlistId, BookId = bookId });
+                seedContext.SaveChanges();
+            }
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new WishlistService(new UnitOfWork(context));
+                await service.AddBookToWishlistAsync(wishlistId, bookId);
+            }
+
+            using (var verifyContext = new ApplicationDbContext(opts))
+            {
+                var count = verifyContext.WishlistBooks.Count(wb => wb.WishlistId == wishlistId && wb.BookId == bookId);
+                Assert.Equal(1, count); // Should still be only one
+            }
+        }
+
+        [Fact]
+        public async Task RemoveBookFromWishlistAsync_WhenBookExists_ShouldRemoveBook()
+        {
+            var opts = CreateNewContextOptions(nameof(RemoveBookFromWishlistAsync_WhenBookExists_ShouldRemoveBook));
+            var wishlistId = Guid.NewGuid();
+            var bookId = Guid.NewGuid();
+            using (var seedContext = new ApplicationDbContext(opts))
+            {
+                seedContext.Books.Add(new Book {
+                    Id = bookId,
+                    Title = "Book",
+                    CoverImageUrl = "cover.jpg",
+                    Description = "desc",
+                    ISBN = "isbn",
+                    PublishedDate = DateTime.UtcNow,
+                    CategoryId = Guid.NewGuid()
+                });
+                seedContext.Wishlists.Add(new Wishlist { Id = wishlistId, Name = "Wishlist", UserId = "user" });
+                seedContext.WishlistBooks.Add(new WishlistBook { WishlistId = wishlistId, BookId = bookId });
+                seedContext.SaveChanges();
+            }
+
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new WishlistService(new UnitOfWork(context));
+                await service.RemoveBookFromWishlistAsync(wishlistId, bookId);
+            }
+
+            using (var verifyContext = new ApplicationDbContext(opts))
+            {
+                var wishlistBook = verifyContext.WishlistBooks.SingleOrDefault(wb => wb.WishlistId == wishlistId && wb.BookId == bookId);
+                Assert.Null(wishlistBook);
+            }
+        }
+
+        [Fact]
+        public async Task RemoveBookFromWishlistAsync_WhenBookDoesNotExist_ShouldNotThrowException()
+        {
+            var opts = CreateNewContextOptions(nameof(RemoveBookFromWishlistAsync_WhenBookDoesNotExist_ShouldNotThrowException));
+            var wishlistId = Guid.NewGuid();
+            var bookId = Guid.NewGuid();
+            // No seeding
+            using (var context = new ApplicationDbContext(opts))
+            {
+                var service = new WishlistService(new UnitOfWork(context));
+                await service.RemoveBookFromWishlistAsync(wishlistId, bookId);
+            }
+            // No exception means pass
+        }
+    }
+} 


### PR DESCRIPTION
- Add UserServiceTests with comprehensive user management scenarios
- Add EventServiceTests for event handling functionality
- Add PublisherServiceTests for publisher operations
- Add WishlistServiceTests for wishlist management
- Implement in-memory database testing setup for all services
- Add test coverage for edge cases and social login scenarios